### PR TITLE
Add comprehensive Spring Boot testing guidance (unit, slices, Testcontainers, integration)

### DIFF
--- a/skills/spring-boot/SKILL.md
+++ b/skills/spring-boot/SKILL.md
@@ -48,14 +48,15 @@ If Thymeleaf is used for view templates, refer [references/thymeleaf.md](referen
 
 ## Testing
 
-Match the test to what you are testing — push each test as far down the pyramid as it will go (unit → slice → integration). Full `@SpringBootTest` is slow; use it sparingly. For the level decision, and how a large suite stays fast (context caching, one container for the whole suite), read [references/testing-strategy.md](references/testing-strategy.md).
+Write tests at complementary levels — unit, sliced Spring tests, and at least one end-to-end/smoke test. They are **not** either/or: each catches bugs the others can't (a green unit test still passes when a mapping or annotation is broken). Most framework-touching tests belong at the fast **sliced** level (`@SpringBootTest(classes = …)` or a slice annotation); keep full-context `@SpringBootTest` for a smoke test plus a request-level end-to-end. For the level decision and keeping a large suite fast (context caching, one container for the suite), read [references/testing-strategy.md](references/testing-strategy.md).
 
 | What you're testing | Level | Reference |
 |---|---|---|
 | Business/domain logic, no framework | Unit (no Spring context) | [testing-unit-mocking.md](references/testing-unit-mocking.md) |
 | JPA / JDBC / JdbcClient / Spring Data JDBC / jOOQ queries | Persistence slice + Testcontainers | [testing-slices-persistence.md](references/testing-slices-persistence.md) |
 | Controller, JSON serialization, or a REST client | Web slice (`@WebMvcTest`/`@JsonTest`/`@RestClientTest`) | [testing-slices-web.md](references/testing-slices-web.md) |
-| The assembled system / external HTTP (WireMock) | Integration `@SpringBootTest` | [testing-integration.md](references/testing-integration.md) |
+| A few components together / external HTTP (WireMock) | Sliced `@SpringBootTest(classes = …)` | [testing-integration.md](references/testing-integration.md) |
+| Whole app starts / one real request end-to-end | Smoke + request-level e2e | [testing-integration.md](references/testing-integration.md) |
 | Full REST API over a real port (`RestTestClient`) | End-to-end | [spring-boot-rest-api-testing.md](references/spring-boot-rest-api-testing.md) |
 | A view-rendering controller (`MockMvcTester`) | Web slice | [spring-boot-webapp-testing-with-mockmvctester.md](references/spring-boot-webapp-testing-with-mockmvctester.md) |
 | Wiring a container (`@ServiceConnection` / dynamic properties) | — | [testcontainers-wiring.md](references/testcontainers-wiring.md) |

--- a/skills/spring-boot/SKILL.md
+++ b/skills/spring-boot/SKILL.md
@@ -48,16 +48,15 @@ If Thymeleaf is used for view templates, refer [references/thymeleaf.md](referen
 
 ## Testing
 
-Write tests at complementary levels — unit, sliced Spring tests, and at least one end-to-end/smoke test. They are **not** either/or: each catches bugs the others can't (a green unit test still passes when a mapping or annotation is broken). Most framework-touching tests belong at the fast **sliced** level (`@SpringBootTest(classes = …)` or a slice annotation); keep full-context `@SpringBootTest` for a smoke test plus a request-level end-to-end. For the level decision and keeping a large suite fast (context caching, one container for the suite), read [references/testing-strategy.md](references/testing-strategy.md).
+Write tests at complementary levels — unit, sliced Spring tests, and at least one end-to-end/smoke test; the levels are not either/or. Most framework-touching tests belong at the fast **sliced** level (`@SpringBootTest(classes = …)` or a slice annotation); keep full-context `@SpringBootTest` for a smoke test plus a request-level end-to-end. For why the levels are complementary and how to keep a large suite fast (context caching, one container for the suite), read [references/testing-strategy.md](references/testing-strategy.md).
 
 | What you're testing | Level | Reference |
 |---|---|---|
 | Business/domain logic, no framework | Unit (no Spring context) | [testing-unit-mocking.md](references/testing-unit-mocking.md) |
 | JPA / JDBC / JdbcClient / Spring Data JDBC / jOOQ queries | Persistence slice + Testcontainers | [testing-slices-persistence.md](references/testing-slices-persistence.md) |
 | Controller, JSON serialization, or a REST client | Web slice (`@WebMvcTest`/`@JsonTest`/`@RestClientTest`) | [testing-slices-web.md](references/testing-slices-web.md) |
-| A few components together / external HTTP (WireMock) | Sliced `@SpringBootTest(classes = …)` | [testing-integration.md](references/testing-integration.md) |
-| Whole app starts / one real request end-to-end | Smoke + request-level e2e | [testing-integration.md](references/testing-integration.md) |
-| Full REST API over a real port (`RestTestClient`) | End-to-end | [spring-boot-rest-api-testing.md](references/spring-boot-rest-api-testing.md) |
+| A few components together, external HTTP (WireMock), or a startup/request-level smoke test | Sliced `@SpringBootTest(classes = …)` or smoke test | [testing-integration.md](references/testing-integration.md) |
+| Full REST API over a real port, full `BaseIT` suite (`RestTestClient`) | End-to-end | [spring-boot-rest-api-testing.md](references/spring-boot-rest-api-testing.md) |
 | A view-rendering controller (`MockMvcTester`) | Web slice | [spring-boot-webapp-testing-with-mockmvctester.md](references/spring-boot-webapp-testing-with-mockmvctester.md) |
 | Wiring a container (`@ServiceConnection` / dynamic properties) | — | [testcontainers-wiring.md](references/testcontainers-wiring.md) |
 

--- a/skills/spring-boot/SKILL.md
+++ b/skills/spring-boot/SKILL.md
@@ -46,12 +46,21 @@ Build a modular monolith with Spring Modulith using [references/spring-modulith.
 
 If Thymeleaf is used for view templates, refer [references/thymeleaf.md](references/thymeleaf.md)
 
-## REST API Testing
+## Testing
 
-If building a REST API using Spring WebMVC, test Spring Boot REST APIs using [references/spring-boot-rest-api-testing.md](references/spring-boot-rest-api-testing.md).
+Match the test to what you are testing — push each test as far down the pyramid as it will go (unit → slice → integration). Full `@SpringBootTest` is slow; use it sparingly. For the level decision, and how a large suite stays fast (context caching, one container for the whole suite), read [references/testing-strategy.md](references/testing-strategy.md).
 
-### Web App Controller Testing
-If building a web application using view rendering controllers, test the controller layer using [references/spring-boot-webapp-testing-with-mockmvctester.md](references/spring-boot-webapp-testing-with-mockmvctester.md).
+| What you're testing | Level | Reference |
+|---|---|---|
+| Business/domain logic, no framework | Unit (no Spring context) | [testing-unit-mocking.md](references/testing-unit-mocking.md) |
+| JPA / JDBC / JdbcClient / Spring Data JDBC / jOOQ queries | Persistence slice + Testcontainers | [testing-slices-persistence.md](references/testing-slices-persistence.md) |
+| Controller, JSON serialization, or a REST client | Web slice (`@WebMvcTest`/`@JsonTest`/`@RestClientTest`) | [testing-slices-web.md](references/testing-slices-web.md) |
+| The assembled system / external HTTP (WireMock) | Integration `@SpringBootTest` | [testing-integration.md](references/testing-integration.md) |
+| Full REST API over a real port (`RestTestClient`) | End-to-end | [spring-boot-rest-api-testing.md](references/spring-boot-rest-api-testing.md) |
+| A view-rendering controller (`MockMvcTester`) | Web slice | [spring-boot-webapp-testing-with-mockmvctester.md](references/spring-boot-webapp-testing-with-mockmvctester.md) |
+| Wiring a container (`@ServiceConnection` / dynamic properties) | — | [testcontainers-wiring.md](references/testcontainers-wiring.md) |
+
+All persistence and integration tests use **Testcontainers with a real database** (never in-memory H2); see [references/testcontainers-wiring.md](references/testcontainers-wiring.md) for `@ServiceConnection` vs dynamic-property wiring.
 
 ### Write ArchUnit Tests
 To write tests for testing the architecture using ArchUnit, refer [references/archunit.md](references/archunit.md)

--- a/skills/spring-boot/references/spring-boot-rest-api-testing.md
+++ b/skills/spring-boot/references/spring-boot-rest-api-testing.md
@@ -5,6 +5,10 @@
 - [BaseIT](#baseitjava)
 - [Sample controller test](#sample-restcontroller-test)
 
+> This is the end-to-end (real-port) layer. For choosing the right test level and keeping the suite fast, see [testing-strategy.md](testing-strategy.md); for stubbing external HTTP called during these tests, see [testing-integration.md](testing-integration.md).
+>
+> **3.5.x vs 4.x:** `RestTestClient` + `@AutoConfigureRestTestClient` are Boot 4.x (module `spring-boot-resttestclient`); `@AutoConfigureTestRestTemplate` is also required on 4.x. On **3.5.x** use `WebTestClient` or `TestRestTemplate` instead, the Jackson 2 (`com.fasterxml.jackson`) mapper, and Testcontainers **1.x** coordinates (`org.testcontainers:junit-jupiter`, `:postgresql`, `org.testcontainers.containers.PostgreSQLContainer`).
+
 ## Key principles
 
 Follow these principles when testing Spring Boot Web MVC REST APIs:

--- a/skills/spring-boot/references/spring-boot-rest-api-testing.md
+++ b/skills/spring-boot/references/spring-boot-rest-api-testing.md
@@ -7,7 +7,7 @@
 
 > This is the end-to-end (real-port) layer. For choosing the right test level and keeping the suite fast, see [testing-strategy.md](testing-strategy.md); for stubbing external HTTP called during these tests, see [testing-integration.md](testing-integration.md).
 >
-> **3.5.x vs 4.x:** `RestTestClient` + `@AutoConfigureRestTestClient` are Boot 4.x (module `spring-boot-resttestclient`); `@AutoConfigureTestRestTemplate` is also required on 4.x. On **3.5.x** use `WebTestClient` or `TestRestTemplate` instead, the Jackson 2 (`com.fasterxml.jackson`) mapper, and Testcontainers **1.x** coordinates (`org.testcontainers:junit-jupiter`, `:postgresql`, `org.testcontainers.containers.PostgreSQLContainer`).
+> **3.5.x vs 4.x:** `RestTestClient` + `@AutoConfigureRestTestClient` are Boot 4.x (module `spring-boot-resttestclient`); `@AutoConfigureTestRestTemplate` is also required on 4.x. On **3.5.x** use `WebTestClient` or `TestRestTemplate` instead, the Jackson 2 (`com.fasterxml.jackson`) mapper, and Testcontainers **1.x** coordinates (see [testcontainers-wiring.md](testcontainers-wiring.md)).
 
 ## Key principles
 

--- a/skills/spring-boot/references/spring-boot-rest-api-testing.md
+++ b/skills/spring-boot/references/spring-boot-rest-api-testing.md
@@ -7,7 +7,7 @@
 
 > This is the end-to-end (real-port) layer. For choosing the right test level and keeping the suite fast, see [testing-strategy.md](testing-strategy.md); for stubbing external HTTP called during these tests, see [testing-integration.md](testing-integration.md).
 >
-> **3.5.x vs 4.x:** `RestTestClient` + `@AutoConfigureRestTestClient` are Boot 4.x (module `spring-boot-resttestclient`); `@AutoConfigureTestRestTemplate` is also required on 4.x. On **3.5.x** use `WebTestClient` or `TestRestTemplate` instead, the Jackson 2 (`com.fasterxml.jackson`) mapper, and Testcontainers **1.x** coordinates (see [testcontainers-wiring.md](testcontainers-wiring.md)).
+> **3.5.x vs 4.x:** the REST test client module differs by version — see [testing-integration.md](testing-integration.md); the JSON mapper package differs — see [testing-slices-web.md](testing-slices-web.md); Testcontainers coordinates differ — see [testcontainers-wiring.md](testcontainers-wiring.md).
 
 ## Key principles
 

--- a/skills/spring-boot/references/spring-boot-webapp-testing-with-mockmvctester.md
+++ b/skills/spring-boot/references/spring-boot-webapp-testing-with-mockmvctester.md
@@ -1,5 +1,9 @@
 # Spring Boot Web Application Testing with MockMvcTester
 
+> This is the web slice. For choosing the right test level see [testing-strategy.md](testing-strategy.md); for `@JsonTest` / `@RestClientTest` and the "security isn't auto-applied in slices — `@Import(SecurityConfig.class)`" gotcha, see [testing-slices-web.md](testing-slices-web.md).
+>
+> **3.5.x vs 4.x:** `MockMvcTester` is Boot 3.4+ (works on both lines). `@MockitoBean` replaces `@MockBean`, which is deprecated on 3.5.x and **removed on 4.x**. The web slice test starter is `spring-boot-starter-test` on 3.5.x and `spring-boot-starter-webmvc-test` on 4.x.
+
 ## Key principles
 
 Follow these principles when testing Spring Boot Web MVC controllers with MockMvcTester:

--- a/skills/spring-boot/references/spring-boot-webapp-testing-with-mockmvctester.md
+++ b/skills/spring-boot/references/spring-boot-webapp-testing-with-mockmvctester.md
@@ -2,7 +2,7 @@
 
 > This is the web slice. For choosing the right test level see [testing-strategy.md](testing-strategy.md); for `@JsonTest` / `@RestClientTest` and the "security isn't auto-applied in slices — `@Import(SecurityConfig.class)`" gotcha, see [testing-slices-web.md](testing-slices-web.md).
 >
-> **3.5.x vs 4.x:** `MockMvcTester` is Boot 3.4+ (works on both lines). `@MockitoBean` replaces `@MockBean`, which is deprecated on 3.5.x and **removed on 4.x**. The web slice test starter is `spring-boot-starter-test` on 3.5.x and `spring-boot-starter-webmvc-test` on 4.x.
+> **3.5.x vs 4.x:** `MockMvcTester` works on both lines (3.4+). For the `@MockBean` → `@MockitoBean` change, see [testing-strategy.md](testing-strategy.md); for the web slice test starter difference, see [testing-slices-web.md](testing-slices-web.md).
 
 ## Key principles
 

--- a/skills/spring-boot/references/testcontainers-wiring.md
+++ b/skills/spring-boot/references/testcontainers-wiring.md
@@ -94,14 +94,50 @@ DynamicPropertyRegistrar mailProperties(GenericContainer<?> mailhog) {
   hard-coded `5432`) — causes port clashes and flaky parallel runs; let Testcontainers
   map a random port and read it lazily.
 
+## When Docker isn't available
+
+Without Docker, a Testcontainers test **hard-fails** by default. Choose how to handle a
+Docker-less environment based on how the container is declared:
+
+- **`@Testcontainers` + `@Container` (static field):** set
+  `@Testcontainers(disabledWithoutDocker = true)` — JUnit then *skips* the class instead of
+  failing when Docker is absent.
+
+  ```java
+  @DataJpaTest
+  @Testcontainers(disabledWithoutDocker = true)
+  class OrderRepositoryTest { /* @Container static PostgreSQLContainer ... */ }
+  ```
+
+- **`@ServiceConnection` `@Bean` (Siva's / Bakker's style, via `@Import`):** there is **no**
+  `@Testcontainers` annotation to carry `disabledWithoutDocker`, and the container starts
+  when the context loads — so gate the class with a JUnit condition. `@EnabledIf` takes a
+  `Class#staticMethod` reference (it can't call the API inline), so point it at a helper:
+
+  ```java
+  static boolean dockerAvailable() {
+      return DockerClientFactory.instance().isDockerAvailable();
+  }
+
+  @EnabledIf("com.example.DockerCondition#dockerAvailable")
+  class OrderIntegrationTest extends BaseIT { /* ... */ }
+  ```
+
+  Simplest alternative: `assumeTrue(DockerClientFactory.instance().isDockerAvailable())` in
+  `@BeforeAll`. Or `@Tag("docker")` + exclude the tag in Docker-less runs.
+
+- **CI caveat — don't skip silently.** Skipping is a convenience for *local* dev without
+  Docker; a Testcontainers test that is silently skipped in **CI** is false confidence — the
+  same trap as passing on H2. Ensure CI has Docker or **Testcontainers Cloud** (Bakker's
+  approach for Docker-less Jenkins hosts) so these tests actually run — see
+  [testing-strategy.md](testing-strategy.md).
+
 ## 3.5.x vs 4.x
 
 Both `@ServiceConnection` (3.1+) and `DynamicPropertyRegistrar` (3.4+) exist in both
-lines. The difference is Testcontainers coordinates: **1.x** on Boot 3.5.x
-(`org.testcontainers:junit-jupiter`, `:postgresql`, `org.testcontainers.containers.*`)
-vs **2.x** on Boot 4.x (`testcontainers-junit-jupiter`, `testcontainers-postgresql`,
-`org.testcontainers.postgresql.PostgreSQLContainer`). See
-[spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) for the 2.x note.
+lines. The difference is Testcontainers coordinates — **1.x** on Boot 3.5.x vs **2.x** on
+Boot 4.x; see [spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) for the
+full artifact-id mapping.
 
 ---
 

--- a/skills/spring-boot/references/testcontainers-wiring.md
+++ b/skills/spring-boot/references/testcontainers-wiring.md
@@ -1,0 +1,112 @@
+# Testcontainers Wiring: @ServiceConnection vs Dynamic Properties
+
+How to connect a Spring Boot test to a Testcontainers container **correctly**. Two
+mechanisms exist, and choosing wrong is the single most common Testcontainers mistake.
+
+- [Rule: @ServiceConnection first](#serviceconnection)
+- [What goes where: the three-way rule](#dynamic-vs-static-properties)
+
+See [testing-slices-persistence.md](testing-slices-persistence.md) and
+[testing-integration.md](testing-integration.md) for where this is applied.
+
+## @ServiceConnection {#serviceconnection}
+
+Use `@ServiceConnection` (Spring Boot 3.1+) whenever Spring Boot ships a
+`ConnectionDetailsFactory` for the container. Boot then reads the container's mapped
+host/port/URL/credentials and wires the matching `*ConnectionDetails` bean **for you** —
+you register **no** properties.
+
+Containers with a built-in factory (verified against the Boot 4.x reference):
+
+- **JDBC databases** (`JdbcConnectionDetails` for any `JdbcDatabaseContainer`: Postgres,
+  MySQL, MariaDB, Oracle, MSSQL) and the **R2DBC** equivalents
+- MongoDB, Redis, Cassandra, Couchbase, Elasticsearch, Neo4j
+- Kafka (incl. Confluent/Redpanda), RabbitMQ, ActiveMQ, Artemis, Pulsar
+- Zipkin, OpenTelemetry (OTLP logging/metrics/tracing), LDAP, Flyway, Liquibase
+
+```java
+@Container
+@ServiceConnection
+static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:18-alpine");
+```
+
+For a `GenericContainer` (no specific container type), give the factory a name hint:
+
+```java
+@Bean
+@ServiceConnection(name = "redis")
+GenericContainer<?> redis() {
+    return new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+}
+```
+
+**No factory?** (e.g. MailHog, a bespoke service.) `@ServiceConnection` does nothing —
+fall back to dynamic properties below. Siva's `TestcontainersConfig` in
+[spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) shows both in one file:
+`@ServiceConnection` for Postgres/Redis, a `DynamicPropertyRegistrar` for MailHog's
+`spring.mail.*`.
+
+## What goes where: the three-way rule {#dynamic-vs-static-properties}
+
+LLMs (and people) routinely put static config into `@DynamicPropertySource` and try to
+pin dynamic ports into properties files. Decide with this table:
+
+| The value is… | Put it in… | Why |
+|---|---|---|
+| Connection details for a container with a factory | **nowhere** — `@ServiceConnection` | auto-wired; registering it manually is redundant and can conflict |
+| Known **only after the container starts** (mapped host/port/URL of a *factory-less* container) | `DynamicPropertyRegistrar` bean (preferred) or `@DynamicPropertySource` (lazy `Supplier`) | the mapped port is assigned at `start()`, not when you write the test |
+| Fixed and known **when you write the test** (`spring.jpa.hibernate.ddl-auto`, feature flags, disabled scheduler, cache TTL, log levels, fixed creds) | `application-test.properties` / `@TestPropertySource` | static config; belongs in a properties file |
+
+**Mental model:** `@DynamicPropertySource` is for values that *don't exist yet at
+authoring time* — that is why the API takes a `Supplier`, not a `String`. Anything you
+could type as a literal into a `.properties` file does not belong there.
+
+```java
+// Correct: a factory-less container's mapped port, resolved lazily at runtime
+@DynamicPropertySource
+static void mailProps(DynamicPropertyRegistry registry) {
+    registry.add("spring.mail.host", mailhog::getHost);
+    registry.add("spring.mail.port", mailhog::getFirstMappedPort);
+}
+```
+
+### Prefer `DynamicPropertyRegistrar` (bean) over the static method
+
+The `DynamicPropertyRegistrar` bean (Spring Boot 3.4+) is preferred over a static
+`@DynamicPropertySource` method: it can depend on other beans, lives cleanly in a
+`@TestConfiguration`, and orders correctly alongside `@ServiceConnection`.
+
+```java
+@Bean
+DynamicPropertyRegistrar mailProperties(GenericContainer<?> mailhog) {
+    return registry -> {
+        registry.add("spring.mail.host", mailhog::getHost);
+        registry.add("spring.mail.port", mailhog::getFirstMappedPort);
+    };
+}
+```
+
+### Two anti-patterns to reject
+
+- **Static value in `@DynamicPropertySource`** (e.g. registering `ddl-auto` there) — it
+  belongs in `application-test.properties`.
+- **Dynamic port pinned to a static file / fixed host ports** (`withFixedExposedPorts`,
+  hard-coded `5432`) — causes port clashes and flaky parallel runs; let Testcontainers
+  map a random port and read it lazily.
+
+## 3.5.x vs 4.x
+
+Both `@ServiceConnection` (3.1+) and `DynamicPropertyRegistrar` (3.4+) exist in both
+lines. The difference is Testcontainers coordinates: **1.x** on Boot 3.5.x
+(`org.testcontainers:junit-jupiter`, `:postgresql`, `org.testcontainers.containers.*`)
+vs **2.x** on Boot 4.x (`testcontainers-junit-jupiter`, `testcontainers-postgresql`,
+`org.testcontainers.postgresql.PostgreSQLContainer`). See
+[spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) for the 2.x note.
+
+---
+
+*Testcontainers patterns credit **Siva Prasad Reddy Katamreddy** —
+[testcontainers-samples](https://github.com/sivaprasadreddy/testcontainers-samples),
+[sivalabs.in/tags/testcontainers](https://www.sivalabs.in/tags/testcontainers/) — and
+**Philip Riecks**, *Testing Spring Boot Applications Demystified* (v4.0). `@ServiceConnection`
+support matrix verified against the official Spring Boot 4.x testing reference.*

--- a/skills/spring-boot/references/testing-integration.md
+++ b/skills/spring-boot/references/testing-integration.md
@@ -1,0 +1,100 @@
+# Integration & End-to-End Testing (@SpringBootTest, WireMock)
+
+`@SpringBootTest` loads the whole application context — every bean, all auto-config. It is
+the slowest layer (startup ~5–30s vs ~1–5s for a slice), so use it **sparingly**, for the
+things that only break when the system is assembled. For everything else, use a slice
+([testing-slices-web.md](testing-slices-web.md),
+[testing-slices-persistence.md](testing-slices-persistence.md)) and keep the suite fast
+([testing-strategy.md](testing-strategy.md)).
+
+## When a full integration test is justified
+
+- Critical end-to-end workflows: registration/login, payment, order fulfilment,
+  data import/export
+- Interactions spanning controller → service → repository → database
+- External API integration (client config, retries, timeouts, response mapping)
+- Security flows across the whole chain (authn/authz)
+
+**Not** for: simple business logic (unit test), single repository queries (`@DataJpaTest`),
+controller request mapping (`@WebMvcTest`), or JSON serialization (`@JsonTest`).
+
+## Full REST API over a real port (end-to-end)
+
+For a closed-box test that drives the app only through HTTP, use
+`@SpringBootTest(webEnvironment = RANDOM_PORT)` with a Testcontainers database. This is the
+top of the pyramid — keep it thin. Siva's
+[spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) covers the full
+`BaseIT` + `RestTestClient` setup; use that as the canonical pattern rather than
+duplicating it here. `RANDOM_PORT` picks a free port so these tests run in parallel
+without clashes.
+
+## External HTTP: built-in first, WireMock when you need a port
+
+A full integration test will call whatever external services your code depends on — and
+those calls fail (or hit the network) unless you stub them. Two tools, in order:
+
+1. **Default — `@RestClientTest` + `MockRestServiceServer`** for `RestClient`/`RestTemplate`
+   clients. In-process, no port, no dependency. See
+   [testing-slices-web.md](testing-slices-web.md).
+
+2. **Escalate to WireMock** only when the built-in stub can't do the job — because WireMock
+   runs a *real* HTTP server on a port, and that is exactly what buys you the extra
+   capability:
+   - the client is `WebClient`, an HTTP-interface client, or a third-party SDK with its
+     own HTTP stack (`MockRestServiceServer` can't intercept these)
+   - you need real socket behaviour: connection timeouts, TLS, retries, streaming
+   - fault/latency injection, record/replay, or a stub shared across the full
+     `@SpringBootTest`
+
+   **Rule of thumb: built-in for the slice, WireMock for the port.**
+
+WireMock 3.x is `org.wiremock:wiremock-standalone` (test scope). Because its port is
+assigned when the server starts, its base URL is a textbook
+`@DynamicPropertySource` value — not something you can hard-code (see
+[testcontainers-wiring.md](testcontainers-wiring.md)):
+
+```java
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Import(TestcontainersConfig.class)
+class CheckoutIntegrationTest {
+
+    @RegisterExtension
+    static WireMockExtension wm = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @DynamicPropertySource
+    static void paymentServiceProps(DynamicPropertyRegistry registry) {
+        registry.add("app.payments.base-url", wm::baseUrl);  // known only after wm starts
+    }
+
+    @Autowired RestTestClient restTestClient;
+
+    @Test
+    void checkoutChargesViaPaymentService() {
+        wm.stubFor(post("/charge").willReturn(okJson("{\"status\":\"PAID\"}")));
+
+        restTestClient.post().uri("/api/checkout")
+                .exchange()
+                .expectStatus().isOk();
+    }
+}
+```
+
+## 3.5.x vs 4.x
+
+- `@SpringBootTest`, `RANDOM_PORT`, `@ServiceConnection`, and WireMock are the same across
+  both lines.
+- **REST test client**: on 4.x prefer `RestTestClient` (with `@AutoConfigureRestTestClient`)
+  or `TestRestTemplate` (with `@AutoConfigureTestRestTemplate` — required on 4.x); both live
+  in the new `spring-boot-resttestclient` module. On 3.5.x use `WebTestClient` or
+  `TestRestTemplate` (no `RestTestClient`, no `@AutoConfigureTestRestTemplate` needed).
+- Testcontainers coordinates: 1.x (3.5.x) vs 2.x (4.x).
+- 4.x-only: **context pausing** (Spring Framework 7) freezes `@Scheduled` tasks and
+  listeners in cached contexts between tests — see [testing-strategy.md](testing-strategy.md).
+
+---
+
+*Integration-testing patterns, including the WireMock approach, credit **Philip Riecks**,
+*Testing Spring Boot Applications Demystified* (v4.0). API details verified against the
+official Spring Boot 4.x testing reference.*

--- a/skills/spring-boot/references/testing-integration.md
+++ b/skills/spring-boot/references/testing-integration.md
@@ -130,7 +130,7 @@ public class PostgresTestContainerConfig {
     @Bean
     @ServiceConnection                                   // wires spring.datasource.* — no manual props
     PostgreSQLContainer<?> postgres() {
-        return new PostgreSQLContainer<>("postgres:16-alpine")   // pin the tag, never untagged/latest
+        return new PostgreSQLContainer<>("postgres:18-alpine")   // pin the tag, never untagged/latest
                 .withInitScript("shows.sql");
     }
 }
@@ -150,6 +150,11 @@ Notes:
   consolidate shared ones in a base class to preserve context reuse (see
   [testing-strategy.md](testing-strategy.md)). Boot 4 / Spring Framework 7 improves
   bean-override ergonomics here.
+- If the suite already imports the shared `TestcontainersConfig` (from
+  [spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md)) for the e2e layer,
+  reuse it here instead of `PostgresTestContainerConfig` — two different container
+  configs in the same suite means two Postgres containers and two context-cache
+  families.
 
 ## Full REST API over a real port (end-to-end)
 
@@ -209,7 +214,8 @@ class CheckoutIntegrationTest {
 - **REST test client**: on 4.x prefer `RestTestClient` (`@AutoConfigureRestTestClient`) or
   `TestRestTemplate` (`@AutoConfigureTestRestTemplate` — required on 4.x); both live in the
   new `spring-boot-resttestclient` module. On 3.5.x use `WebTestClient`/`TestRestTemplate`.
-- Testcontainers coordinates: 1.x (3.5.x) vs 2.x (4.x).
+- Testcontainers coordinates: 1.x (3.5.x) vs 2.x (4.x) — see
+  [testcontainers-wiring.md](testcontainers-wiring.md).
 - **Test-autoconfigure annotations moved packages in Boot 4** (modular restructuring), so
   the imports in a custom slice like `@EnableDatabaseTest` differ by version — let your IDE
   resolve them. For example: `AutoConfigureDataJpa` is `org.springframework.boot.data.jpa.test.autoconfigure`

--- a/skills/spring-boot/references/testing-integration.md
+++ b/skills/spring-boot/references/testing-integration.md
@@ -1,56 +1,118 @@
-# Integration & End-to-End Testing (@SpringBootTest, WireMock)
+# Integration, Sliced-Context & End-to-End Testing
 
-`@SpringBootTest` loads the whole application context — every bean, all auto-config. It is
-the slowest layer (startup ~5–30s vs ~1–5s for a slice), so use it **sparingly**, for the
-things that only break when the system is assembled. For everything else, use a slice
-([testing-slices-web.md](testing-slices-web.md),
-[testing-slices-persistence.md](testing-slices-persistence.md)) and keep the suite fast
-([testing-strategy.md](testing-strategy.md)).
+`@SpringBootTest` spans a range — from a **full-context smoke test** (boots everything) to a
+fast **sliced-context test** (`classes = { … }`, boots only what you list). These
+**complement** the single-annotation slices and unit tests; you write all of them (see
+[testing-strategy.md](testing-strategy.md) for the layered model). This reference covers the
+whole-context and multi-component tests.
 
-## When a full integration test is justified
+## Smoke tests — does the app actually start and serve?
 
-- Critical end-to-end workflows: registration/login, payment, order fulfilment,
-  data import/export
-- Interactions spanning controller → service → repository → database
-- External API integration (client config, retries, timeouts, response mapping)
-- Security flows across the whole chain (authn/authz)
+The cheapest high-value test: prove the whole context wires up. A pure unit test can be
+green while the app is broken (missing/mismatched mapping, bad bean); a smoke test catches
+that class of failure. Write one per application.
 
-**Not** for: simple business logic (unit test), single repository queries (`@DataJpaTest`),
-controller request mapping (`@WebMvcTest`), or JSON serialization (`@JsonTest`).
+```java
+@SpringBootTest
+class ApplicationSmokeTest {
+
+    @Test
+    void contextLoads() { }   // fails on any DI / config / mapping wiring error
+}
+```
+
+Startup succeeding is not the same as the app *working*: an endpoint whose handler
+annotation is missing may still start fine and simply return nothing. So for a web/REST
+service, add **at least one request-level** smoke test that drives a real request through
+the full stack:
+
+```java
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Import(TestcontainersConfig.class)
+class TopLevelRequestSmokeTest {
+
+    @Autowired RestTestClient restTestClient;   // 4.x; on 3.5.x use WebTestClient/TestRestTemplate
+
+    @Test
+    void topEndpointServesAResponse() {
+        restTestClient.get().uri("/api/movies/top10?country=US")
+                .exchange()
+                .expectStatus().isOk();
+    }
+}
+```
+
+## Sliced-context tests: `@SpringBootTest(classes = { … })` — the workhorse
+
+This is the level most of your framework-touching tests should live at. Listing `classes`
+bootstraps **only** those components plus core DI — not the whole app — so it runs about as
+fast as a unit test while exercising the real framework, annotations, mappings, and (via
+Testcontainers) real SQL. Mock the slow/costly externals; keep everything else real.
+
+```java
+@SpringBootTest(classes = { MovieController.class, MovieService.class, ApiExceptionHandler.class })
+@AutoConfigureMockMvc
+@Import(TestcontainersConfig.class)               // real Postgres, not H2
+class MovieControllerSlicedTest {
+
+    @Autowired MockMvcTester mockMvc;
+
+    // Override just the slow/paid external; the controller, service, advice and DB stay real.
+    @TestConfiguration
+    static class StubExternals {
+        @Bean
+        RecommendationClient recommendationClient() {
+            RecommendationClient stub = mock(RecommendationClient.class);
+            when(stub.top10(any())).thenReturn(List.of(1L, 2L, 3L));
+            return stub;
+        }
+    }
+
+    @Test
+    void returnsTop10AndHandlesUnknownCountry() {
+        assertThat(mockMvc.get().uri("/api/movies/top10?country=US")).hasStatusOk();
+        assertThat(mockMvc.get().uri("/api/movies/top10?country=ZZ")).hasStatus(HttpStatus.BAD_REQUEST);
+    }
+}
+```
+
+Notes:
+
+- The built-in slice annotations (`@WebMvcTest`, `@DataJpaTest`, `@JsonTest`, …) are the
+  **same mechanism** — `@SpringBootTest`-style context selection with a preconfigured slice.
+  Prefer them when they fit ([testing-slices-web.md](testing-slices-web.md),
+  [testing-slices-persistence.md](testing-slices-persistence.md)); when they are too
+  limiting, list `classes` explicitly, optionally behind a custom test-slice meta-annotation
+  you reuse across the suite (e.g. `@EnableDatabaseTest` bundling the JPA + Testcontainers
+  setup).
+- To replace a bean, use `@MockitoBean` for a mock, or a `@TestConfiguration` `@Bean` for a
+  custom stub instance. Both change the context cache key, so consolidate them in a shared
+  base class to preserve context reuse (see [testing-strategy.md](testing-strategy.md)).
+  Boot 4 / Spring Framework 7 improves bean-override ergonomics here.
 
 ## Full REST API over a real port (end-to-end)
 
-For a closed-box test that drives the app only through HTTP, use
-`@SpringBootTest(webEnvironment = RANDOM_PORT)` with a Testcontainers database. This is the
-top of the pyramid — keep it thin. Siva's
-[spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) covers the full
-`BaseIT` + `RestTestClient` setup; use that as the canonical pattern rather than
-duplicating it here. `RANDOM_PORT` picks a free port so these tests run in parallel
-without clashes.
+For a closed-box test that drives the app only through HTTP over a real port, use
+`@SpringBootTest(webEnvironment = RANDOM_PORT)` with a Testcontainers database. Siva's
+[spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) has the full
+`BaseIT` + `RestTestClient` pattern — keep this layer thin.
 
 ## External HTTP: built-in first, WireMock when you need a port
 
-A full integration test will call whatever external services your code depends on — and
-those calls fail (or hit the network) unless you stub them. Two tools, in order:
+Full and sliced tests still call whatever external services the code depends on, so stub
+them:
 
 1. **Default — `@RestClientTest` + `MockRestServiceServer`** for `RestClient`/`RestTemplate`
-   clients. In-process, no port, no dependency. See
-   [testing-slices-web.md](testing-slices-web.md).
-
-2. **Escalate to WireMock** only when the built-in stub can't do the job — because WireMock
-   runs a *real* HTTP server on a port, and that is exactly what buys you the extra
-   capability:
-   - the client is `WebClient`, an HTTP-interface client, or a third-party SDK with its
-     own HTTP stack (`MockRestServiceServer` can't intercept these)
-   - you need real socket behaviour: connection timeouts, TLS, retries, streaming
-   - fault/latency injection, record/replay, or a stub shared across the full
-     `@SpringBootTest`
-
+   clients (in-process, no port). See [testing-slices-web.md](testing-slices-web.md). For a
+   costly/slow external inside a larger `@SpringBootTest`, a `@TestConfiguration`/
+   `@MockitoBean` stub of the client bean (as above) is usually enough.
+2. **Escalate to WireMock** only when you need a real HTTP server on a port: the client is
+   `WebClient`/an HTTP-interface/a third-party SDK; you need real timeouts/TLS/retries;
+   fault/latency injection; or a stub shared across the full context.
    **Rule of thumb: built-in for the slice, WireMock for the port.**
 
-WireMock 3.x is `org.wiremock:wiremock-standalone` (test scope). Because its port is
-assigned when the server starts, its base URL is a textbook
-`@DynamicPropertySource` value — not something you can hard-code (see
+WireMock 3.x is `org.wiremock:wiremock-standalone` (test scope). Its port is assigned at
+startup, so its base URL is a textbook `@DynamicPropertySource` value (see
 [testcontainers-wiring.md](testcontainers-wiring.md)):
 
 ```java
@@ -74,27 +136,27 @@ class CheckoutIntegrationTest {
     void checkoutChargesViaPaymentService() {
         wm.stubFor(post("/charge").willReturn(okJson("{\"status\":\"PAID\"}")));
 
-        restTestClient.post().uri("/api/checkout")
-                .exchange()
-                .expectStatus().isOk();
+        restTestClient.post().uri("/api/checkout").exchange().expectStatus().isOk();
     }
 }
 ```
 
 ## 3.5.x vs 4.x
 
-- `@SpringBootTest`, `RANDOM_PORT`, `@ServiceConnection`, and WireMock are the same across
-  both lines.
-- **REST test client**: on 4.x prefer `RestTestClient` (with `@AutoConfigureRestTestClient`)
-  or `TestRestTemplate` (with `@AutoConfigureTestRestTemplate` — required on 4.x); both live
-  in the new `spring-boot-resttestclient` module. On 3.5.x use `WebTestClient` or
-  `TestRestTemplate` (no `RestTestClient`, no `@AutoConfigureTestRestTemplate` needed).
+- `@SpringBootTest` (incl. `classes = …`), `RANDOM_PORT`, `@ServiceConnection`, and WireMock
+  work the same on both lines.
+- **REST test client**: on 4.x prefer `RestTestClient` (`@AutoConfigureRestTestClient`) or
+  `TestRestTemplate` (`@AutoConfigureTestRestTemplate` — required on 4.x); both live in the
+  new `spring-boot-resttestclient` module. On 3.5.x use `WebTestClient`/`TestRestTemplate`.
 - Testcontainers coordinates: 1.x (3.5.x) vs 2.x (4.x).
-- 4.x-only: **context pausing** (Spring Framework 7) freezes `@Scheduled` tasks and
-  listeners in cached contexts between tests — see [testing-strategy.md](testing-strategy.md).
+- 4.x-only: **context pausing** (Spring Framework 7) and improved `@TestConfiguration`
+  bean-override ergonomics — see [testing-strategy.md](testing-strategy.md).
 
 ---
 
-*Integration-testing patterns, including the WireMock approach, credit **Philip Riecks**,
-*Testing Spring Boot Applications Demystified* (v4.0). API details verified against the
-official Spring Boot 4.x testing reference.*
+*The smoke-test and `@SpringBootTest(classes = …)` sliced-context approach credit **Paul
+Bakker** (Netflix, Java Champion), *Testing Spring Boot the Netflix Way* —
+[github.com/paulbakker/testing-spring-boot-presentation](https://github.com/paulbakker/testing-spring-boot-presentation).
+Integration and WireMock patterns credit **Philip Riecks**, *Testing Spring Boot
+Applications Demystified* (v4.0). API details verified against the official Spring Boot 4.x
+testing reference.*

--- a/skills/spring-boot/references/testing-integration.md
+++ b/skills/spring-boot/references/testing-integration.md
@@ -163,6 +163,15 @@ For a closed-box test that drives the app only through HTTP over a real port, us
 [spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) has the full
 `BaseIT` + `RestTestClient` pattern — keep this layer thin.
 
+**Boot 4 — one client across levels.** `RestTestClient` (Spring Framework 7) unifies
+MockMvc and WebTestClient behind a single fluent API, with a bind mode for each test level:
+`bindToController(...)` (no context, mock collaborators by hand), `bindTo(MockMvc)` (over an
+MVC slice), `bindToApplicationContext(...)` (real context), and `bindToServer()` (real
+port). So the same client can span the sliced-to-e2e range rather than switching tools per
+level — a natural fit for the layered model in [testing-strategy.md](testing-strategy.md).
+On 3.5.x there is no `RestTestClient`; use `MockMvcTester`/`WebTestClient`/`TestRestTemplate`.
+*(Credit: [Dan Vega — Spring Framework 7 RestTestClient](https://www.danvega.dev/blog/spring-framework-7-rest-test-client); bind-mode names verified against the Spring Framework 7 `RestTestClient` source.)*
+
 ## External HTTP: built-in first, WireMock when you need a port
 
 Full and sliced tests still call whatever external services the code depends on, so stub

--- a/skills/spring-boot/references/testing-integration.md
+++ b/skills/spring-boot/references/testing-integration.md
@@ -44,51 +44,112 @@ class TopLevelRequestSmokeTest {
 
 ## Sliced-context tests: `@SpringBootTest(classes = { … })` — the workhorse
 
-This is the level most of your framework-touching tests should live at. Listing `classes`
-bootstraps **only** those components plus core DI — not the whole app — so it runs about as
-fast as a unit test while exercising the real framework, annotations, mappings, and (via
-Testcontainers) real SQL. Mock the slow/costly externals; keep everything else real.
+This is the level most framework-touching tests should live at. It has **two building
+blocks** working together:
+
+1. `@SpringBootTest(classes = { … })` registers exactly the components under test (plus a
+   `@TestConfiguration` that stubs slow/costly externals) — not the whole app.
+2. A **test-slice annotation** pulls in the auto-configuration the layer needs. Listing
+   `classes` alone gives you the beans but *not* the framework wiring (JPA repositories, the
+   web/GraphQL layer, …); the slice supplies that. Use a built-in slice (`@WebMvcTest`,
+   `@DataJpaTest`, …) — which is exactly `@SpringBootTest(classes)` + a preselected slice
+   under the hood — or, when you need to combine layers, a **custom meta-annotation** you
+   write once and reuse.
+
+**Mock the external, keep the rest real** — put the stub in a `@TestConfiguration` and list
+it in `classes`:
 
 ```java
-@SpringBootTest(classes = { MovieController.class, MovieService.class, ApiExceptionHandler.class })
-@AutoConfigureMockMvc
-@Import(TestcontainersConfig.class)               // real Postgres, not H2
-class MovieControllerSlicedTest {
-
-    @Autowired MockMvcTester mockMvc;
-
-    // Override just the slow/paid external; the controller, service, advice and DB stay real.
-    @TestConfiguration
-    static class StubExternals {
-        @Bean
-        RecommendationClient recommendationClient() {
-            RecommendationClient stub = mock(RecommendationClient.class);
-            when(stub.top10(any())).thenReturn(List.of(1L, 2L, 3L));
-            return stub;
-        }
+@TestConfiguration
+class StubExternals {
+    @Bean
+    RecommendationClient recommendationClient() {         // the slow/paid dependency
+        var mock = mock(RecommendationClient.class);
+        when(mock.top10("US")).thenReturn(List.of(1L, 2L, 3L));
+        return mock;
     }
+}
+```
+
+**Variant A — mock the repository (fastest; no database).** Unit-test speed, but real
+service wiring:
+
+```java
+@SpringBootTest(classes = { MovieService.class, StubExternals.class })
+class MovieServiceSlicedTest {
+
+    @Autowired MovieService movieService;
+    @MockitoBean MovieRepository movieRepository;   // 3.4+/4.x; @MockBean on older 3.x
 
     @Test
-    void returnsTop10AndHandlesUnknownCountry() {
-        assertThat(mockMvc.get().uri("/api/movies/top10?country=US")).hasStatusOk();
-        assertThat(mockMvc.get().uri("/api/movies/top10?country=ZZ")).hasStatus(HttpStatus.BAD_REQUEST);
+    void ranksTop10() {
+        when(movieRepository.findAllById(any())).thenReturn(List.of(/* ... */));
+        assertThat(movieService.top10("US")).hasSize(3);
+    }
+}
+```
+
+**Variant B — real database via a custom Testcontainers slice.** Drop the repository mock,
+list the real repository, and add a reusable slice that wires JPA + a real Postgres. This
+pays a container start (so it is *not* unit-test fast) but exercises real SQL:
+
+```java
+@SpringBootTest(classes = { MovieService.class, MovieRepository.class, StubExternals.class })
+@EnableDatabaseTest
+class MovieServiceTestcontainersTest {
+
+    @Autowired MovieService movieService;
+
+    @Test
+    void ranksTop10FromRealDb() {
+        assertThat(movieService.top10("US"))
+                .extracting(Movie::title).contains("Stranger Things");
+    }
+}
+```
+
+The `@EnableDatabaseTest` meta-annotation — written **once**, reused across the suite —
+bundles the JPA + Testcontainers wiring (this is Paul Bakker's pattern, adapted):
+
+```java
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@EnableJpaRepositories(basePackages = "com.example.movies.repository")
+@EntityScan("com.example.movies.repository")
+@AutoConfigureDataJpa
+@AutoConfigureTestEntityManager
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)   // keep Postgres, not H2
+@Import(PostgresTestContainerConfig.class)
+public @interface EnableDatabaseTest {}
+```
+
+```java
+@TestConfiguration(proxyBeanMethods = false)
+public class PostgresTestContainerConfig {
+
+    @Bean
+    @ServiceConnection                                   // wires spring.datasource.* — no manual props
+    PostgreSQLContainer<?> postgres() {
+        return new PostgreSQLContainer<>("postgres:16-alpine")   // pin the tag, never untagged/latest
+                .withInitScript("shows.sql");
     }
 }
 ```
 
 Notes:
 
-- The built-in slice annotations (`@WebMvcTest`, `@DataJpaTest`, `@JsonTest`, …) are the
-  **same mechanism** — `@SpringBootTest`-style context selection with a preconfigured slice.
-  Prefer them when they fit ([testing-slices-web.md](testing-slices-web.md),
-  [testing-slices-persistence.md](testing-slices-persistence.md)); when they are too
-  limiting, list `classes` explicitly, optionally behind a custom test-slice meta-annotation
-  you reuse across the suite (e.g. `@EnableDatabaseTest` bundling the JPA + Testcontainers
-  setup).
-- To replace a bean, use `@MockitoBean` for a mock, or a `@TestConfiguration` `@Bean` for a
-  custom stub instance. Both change the context cache key, so consolidate them in a shared
-  base class to preserve context reuse (see [testing-strategy.md](testing-strategy.md)).
-  Boot 4 / Spring Framework 7 improves bean-override ergonomics here.
+- Prefer the built-in slices (`@WebMvcTest`, `@DataJpaTest`, `@JsonTest`) when a single
+  layer is enough — see [testing-slices-web.md](testing-slices-web.md),
+  [testing-slices-persistence.md](testing-slices-persistence.md). Reach for
+  `@SpringBootTest(classes = …)` + a slice when you want a few real layers wired together.
+- Assert through the layer's own entry point — a controller via `@WebMvcTest`+`MockMvcTester`,
+  a service directly, a GraphQL executor, etc. You do **not** need `@AutoConfigureMockMvc` at
+  this level unless you are deliberately exercising the HTTP layer (that belongs to the
+  request-level smoke test above or the e2e test below).
+- `@MockitoBean` and each distinct `@TestConfiguration` change the context cache key;
+  consolidate shared ones in a base class to preserve context reuse (see
+  [testing-strategy.md](testing-strategy.md)). Boot 4 / Spring Framework 7 improves
+  bean-override ergonomics here.
 
 ## Full REST API over a real port (end-to-end)
 

--- a/skills/spring-boot/references/testing-integration.md
+++ b/skills/spring-boot/references/testing-integration.md
@@ -210,6 +210,12 @@ class CheckoutIntegrationTest {
   `TestRestTemplate` (`@AutoConfigureTestRestTemplate` — required on 4.x); both live in the
   new `spring-boot-resttestclient` module. On 3.5.x use `WebTestClient`/`TestRestTemplate`.
 - Testcontainers coordinates: 1.x (3.5.x) vs 2.x (4.x).
+- **Test-autoconfigure annotations moved packages in Boot 4** (modular restructuring), so
+  the imports in a custom slice like `@EnableDatabaseTest` differ by version — let your IDE
+  resolve them. For example: `AutoConfigureDataJpa` is `org.springframework.boot.data.jpa.test.autoconfigure`
+  on 4.x vs `org.springframework.boot.test.autoconfigure.orm.jpa` on 3.5.x; `@EntityScan` is
+  `org.springframework.boot.persistence.autoconfigure` on 4.x vs `org.springframework.boot.autoconfigure.domain`
+  on 3.5.x. (`@EnableJpaRepositories` stays in Spring Data's `org.springframework.data.jpa.repository.config`.)
 - 4.x-only: **context pausing** (Spring Framework 7) and improved `@TestConfiguration`
   bean-override ergonomics — see [testing-strategy.md](testing-strategy.md).
 

--- a/skills/spring-boot/references/testing-slices-persistence.md
+++ b/skills/spring-boot/references/testing-slices-persistence.md
@@ -1,0 +1,144 @@
+# Persistence Slice Testing (JPA, JDBC, Spring Data JDBC, jOOQ)
+
+Test the persistence layer with a slice — not the full context — and back it with a
+**real** database via Testcontainers, not in-memory H2.
+
+## The H2 false-confidence trap
+
+Every persistence slice (`@DataJpaTest`, `@JdbcTest`, `@DataJdbcTest`, `@JooqTest`)
+auto-configures an **embedded** DataSource (H2) by default. Derived queries pass on H2,
+but anything database-specific silently diverges: a Postgres native query using
+`to_tsvector` / `plainto_tsquery` / `ON CONFLICT` / array or JSON columns / sequences
+fails against production even though the H2 test is green (`Function "TO_TSVECTOR" not
+found`). Test against the database you deploy on.
+
+**The rule for all four slices:** add
+`@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)` so the
+DataSource is *not* swapped for H2, and supply a Testcontainers database via
+`@ServiceConnection`. See [testcontainers-wiring.md](testcontainers-wiring.md).
+
+Prefer importing a shared container config (Siva's `TestcontainersConfig`, see
+[spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md)) so one container is
+reused across the whole suite and the context stays cacheable — see
+[testing-strategy.md](testing-strategy.md).
+
+## @DataJpaTest — JPA repositories
+
+```java
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestcontainersConfig.class)   // supplies the @ServiceConnection Postgres container
+class BookRepositoryTest {
+
+    @Autowired BookRepository bookRepository;
+
+    @Test
+    void runsPostgresNativeFullTextSearch() {
+        bookRepository.saveAll(List.of(
+                new Book("978-1", "The Lord of the Rings", "Tolkien"),
+                new Book("978-2", "Fellowship of the Ring", "Tolkien")));
+
+        var results = bookRepository.searchByTitleWithRanking("rings");
+
+        assertThat(results).extracting(Book::title)
+                .containsExactly("The Lord of the Rings", "Fellowship of the Ring");
+    }
+}
+```
+
+Slices are `@Transactional` and roll back after each test; a `TestEntityManager` is
+available for setup, or use `@Sql("/test-data.sql")`.
+
+**What to actually test with `@DataJpaTest`:** custom `@Query` (JPQL and native),
+database-specific features, complex derived queries with edge cases, custom repository
+implementations, and N+1/indexing behaviour. **Don't** test simple derived queries
+(`findById`, `findByTitle`), basic CRUD, or framework behaviour — those are Spring Data's
+responsibility, not yours.
+
+## @JdbcTest — JdbcTemplate and JdbcClient
+
+`@JdbcTest` auto-configures a DataSource plus both `JdbcTemplate` and `JdbcClient` (the
+fluent client, Spring 6.1+ / Boot 3.2+, present in both 3.5.x and 4.x). Same
+`replace = NONE` + Testcontainers rule.
+
+```java
+@JdbcTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestcontainersConfig.class)
+class BookJdbcTest {
+
+    @Autowired JdbcClient jdbcClient;
+
+    @Test
+    void insertsAndCounts() {
+        jdbcClient.sql("insert into books(isbn, title) values (?, ?)")
+                  .params("978-1", "Clean Code").update();
+
+        long count = jdbcClient.sql("select count(*) from books")
+                               .query(Long.class).single();
+
+        assertThat(count).isEqualTo(1);
+    }
+}
+```
+
+## @DataJdbcTest — Spring Data JDBC
+
+For Spring Data JDBC repositories (aggregates, no JPA). Same rule.
+
+```java
+@DataJdbcTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestcontainersConfig.class)
+class OrderRepositoryTest {
+
+    @Autowired OrderRepository orderRepository;
+
+    @Test
+    void persistsAggregate() {
+        var saved = orderRepository.save(new Order("SKU-1", 2));
+        assertThat(orderRepository.findById(saved.id())).isPresent();
+    }
+}
+```
+
+## @JooqTest — jOOQ DSLContext
+
+`@JooqTest` auto-configures a `DSLContext`. Same rule — jOOQ against H2 masks
+dialect-specific SQL.
+
+```java
+@JooqTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestcontainersConfig.class)
+class BookJooqTest {
+
+    @Autowired DSLContext dsl;
+
+    @Test
+    void queriesWithDslContext() {
+        int rows = dsl.insertInto(BOOKS)
+                      .columns(BOOKS.ISBN, BOOKS.TITLE)
+                      .values("978-1", "Clean Code")
+                      .execute();
+        assertThat(rows).isEqualTo(1);
+    }
+}
+```
+
+## 3.5.x vs 4.x
+
+- Slice annotations, `@AutoConfigureTestDatabase`, `@ServiceConnection`, `JdbcClient`, and
+  `TestEntityManager` are identical across both lines.
+- **Testcontainers coordinates differ**: 1.x on 3.5.x vs 2.x on 4.x — see
+  [testcontainers-wiring.md](testcontainers-wiring.md).
+- **jOOQ**: the managed jOOQ major version differs between the Boot 3.5.x and 4.x BOMs;
+  check `spring-boot-dependencies` for your version rather than pinning it yourself.
+
+---
+
+*Persistence-testing patterns credit **Philip Riecks**, *Testing Spring Boot Applications
+Demystified* (v4.0), and Testcontainers patterns credit **Siva Prasad Reddy Katamreddy**
+([testcontainers-samples](https://github.com/sivaprasadreddy/testcontainers-samples),
+[sivalabs.in/tags/testcontainers](https://www.sivalabs.in/tags/testcontainers/)). Slice
+behaviour verified against the official Spring Boot 4.x testing reference.*

--- a/skills/spring-boot/references/testing-slices-web.md
+++ b/skills/spring-boot/references/testing-slices-web.md
@@ -1,0 +1,96 @@
+# Web & Serialization Slice Testing (@WebMvcTest, @JsonTest, @RestClientTest)
+
+Slices for the non-persistence layers. Each loads only its layer's beans, so it is far
+faster than `@SpringBootTest` — see [testing-strategy.md](testing-strategy.md).
+
+## @WebMvcTest — controllers in isolation
+
+Loads the web layer only (controllers, `@ControllerAdvice`, filters, converters,
+`MockMvc`); `@Service`/`@Repository`/`@Component` are **not** loaded, so a collaborator the
+controller needs must be a `@MockitoBean` or the context fails to start.
+
+For the full controller-testing API (request mapping, validation, JSON assertions, view
+rendering), use the existing
+[spring-boot-webapp-testing-with-mockmvctester.md](spring-boot-webapp-testing-with-mockmvctester.md)
+— prefer `MockMvcTester` (AssertJ-style, 3.4+). Two non-obvious gotchas to carry from here:
+
+- **Security is not auto-applied in slices.** With recent Spring Security, `@WebMvcTest`
+  does **not** pick up your custom `SecurityConfig` automatically — `@Import` it explicitly,
+  or your test runs against Boot's default chain (often a surprise 401):
+
+  ```java
+  @WebMvcTest(BookController.class)
+  @Import(SecurityConfig.class)
+  class BookControllerTest {
+      @Autowired MockMvcTester mockMvc;
+      @MockitoBean BookService bookService;   // @Service not on the web slice
+  }
+  ```
+
+- **Simulate authentication** with `spring-boot-starter-security-test` + `@WithMockUser`:
+  `@WithMockUser(roles = "ADMIN")` on a test asserts the secured path; no annotation
+  asserts 401; wrong role asserts 403.
+
+## @JsonTest — serialization of a DTO
+
+Loads only Jackson/JSON configuration and provides `JacksonTester` (also `GsonTester`,
+`JsonbTester`, `BasicJsonTester`). Use it to pin a DTO's wire format.
+
+```java
+@JsonTest
+class BookJsonTest {
+
+    @Autowired JacksonTester<Book> json;
+
+    @Test
+    void serializesBook() throws Exception {
+        assertThat(json.write(new Book("978-1", "Clean Code", "Martin")))
+                .hasJsonPathStringValue("$.isbn")
+                .extractingJsonPathStringValue("$.title").isEqualTo("Clean Code");
+    }
+}
+```
+
+## @RestClientTest — the built-in way to stub external HTTP
+
+For code that **calls out** via `RestClient` or `RestTemplate`, `@RestClientTest`
+auto-configures the client plus a `MockRestServiceServer`. This is the built-in,
+in-process stub: no port, no extra dependency, no real socket. Reach for it first.
+
+```java
+@RestClientTest(WeatherClient.class)
+class WeatherClientTest {
+
+    @Autowired WeatherClient client;
+    @Autowired MockRestServiceServer server;   // auto-configured
+
+    @Test
+    void fetchesForecast() {
+        server.expect(requestTo("/forecast?city=Berlin"))
+              .andRespond(withSuccess("{\"tempC\":21}", MediaType.APPLICATION_JSON));
+
+        assertThat(client.forecastFor("Berlin").tempC()).isEqualTo(21);
+    }
+}
+```
+
+`MockRestServiceServer` only intercepts Spring's `RestClient`/`RestTemplate`. For
+`WebClient`, HTTP-interface clients, third-party SDKs, or when you need a real port
+(timeouts, TLS, fault injection), escalate to WireMock in a full integration test — see
+[testing-integration.md](testing-integration.md).
+
+## 3.5.x vs 4.x
+
+- `@WebMvcTest`, `@JsonTest`, `@RestClientTest`, `MockRestServiceServer`, `JacksonTester`,
+  and `@WithMockUser` are identical across both lines.
+- **`@JsonTest` JSON mapper**: Jackson 2 (`com.fasterxml.jackson`) on 3.5.x vs Jackson 3
+  (`tools.jackson`) on 4.x — the DTO assertions are the same; only the underlying mapper
+  package differs.
+- The web slice test starter is `spring-boot-starter-test` on 3.5.x and
+  `spring-boot-starter-webmvc-test` on 4.x.
+
+---
+
+*Slice-testing patterns credit **Philip Riecks**, *Testing Spring Boot Applications
+Demystified* (v4.0). API details verified against the official Spring Boot 4.x testing
+reference.*

--- a/skills/spring-boot/references/testing-slices-web.md
+++ b/skills/spring-boot/references/testing-slices-web.md
@@ -75,9 +75,8 @@ class WeatherClientTest {
 ```
 
 `MockRestServiceServer` only intercepts Spring's `RestClient`/`RestTemplate`. For
-`WebClient`, HTTP-interface clients, third-party SDKs, or when you need a real port
-(timeouts, TLS, fault injection), escalate to WireMock in a full integration test — see
-[testing-integration.md](testing-integration.md).
+`WebClient`/HTTP-interface/SDK clients or when you need a real port, escalate to WireMock —
+see [testing-integration.md](testing-integration.md) for the full built-in-vs-WireMock rule.
 
 ## 3.5.x vs 4.x
 

--- a/skills/spring-boot/references/testing-strategy.md
+++ b/skills/spring-boot/references/testing-strategy.md
@@ -26,14 +26,16 @@ boot the framework.
 
 Roughly:
 
-- **~95% — sliced Spring tests.** `@SpringBootTest(classes = { … })` bootstraps *only* the
-  components you list (plus core DI), not the whole app — as fast as a unit test, but with
-  the real framework, annotations, and (via Testcontainers) real SQL. Mock the slow/costly
-  externals with a `@TestConfiguration` bean override or `@MockitoBean`; keep the rest
-  real. The built-in slice annotations (`@WebMvcTest`, `@DataJpaTest`, `@JsonTest`, …) are
-  the *same mechanism* with a preconfigured slice — convenient, but sometimes limiting, in
-  which case fall back to an explicit `classes = { … }` list (optionally with a custom
-  test-slice meta-annotation). See [testing-integration.md](testing-integration.md),
+- **~95% — sliced Spring tests.** `@SpringBootTest(classes = { … })` paired with a
+  test-slice annotation bootstraps *only* the components you list (plus the framework the
+  slice provides), not the whole app — with the real framework, annotations, and mappings.
+  Mock the slow/costly externals with a `@TestConfiguration` bean or `@MockitoBean`; keep
+  the rest real. With the repository mocked it runs at ~unit-test speed; with a real
+  database via a Testcontainers slice it pays a container start but exercises real SQL. The
+  built-in slice annotations (`@WebMvcTest`, `@DataJpaTest`, `@JsonTest`, …) are the *same
+  mechanism* with a preconfigured slice — convenient, but sometimes limiting, in which case
+  list `classes` explicitly and add a slice (a built-in one or a custom meta-annotation).
+  See [testing-integration.md](testing-integration.md),
   [testing-slices-web.md](testing-slices-web.md),
   [testing-slices-persistence.md](testing-slices-persistence.md).
 - **At least one smoke test**, plus at least one **request-level** end-to-end test.

--- a/skills/spring-boot/references/testing-strategy.md
+++ b/skills/spring-boot/references/testing-strategy.md
@@ -1,0 +1,83 @@
+# Testing Strategy: Choosing the Level & Keeping the Suite Fast
+
+Read this to decide *which kind* of test to write, and why a large Spring Boot suite stays
+fast. The individual how-tos live in the leaf references linked below.
+
+## Match the test to what you are testing
+
+The pyramid: many fast **unit** tests at the base, fewer **slice** tests in the middle, a
+thin layer of **integration/e2e** tests on top.
+
+| You are testing… | Level | Reference |
+|---|---|---|
+| Business/domain logic, no framework | Unit (no context) | [testing-unit-mocking.md](testing-unit-mocking.md) |
+| Repository / JDBC / jOOQ queries | Persistence slice + Testcontainers | [testing-slices-persistence.md](testing-slices-persistence.md) |
+| Controller, JSON, or a REST client | Web slice | [testing-slices-web.md](testing-slices-web.md) |
+| The assembled system / external HTTP | Integration `@SpringBootTest` | [testing-integration.md](testing-integration.md) |
+| Full REST API over a real port | End-to-end | [spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) |
+
+The common failure is the **wrong altitude** — reaching for `@SpringBootTest` to test
+pure logic. Full context startup is ~5–15s (medium app) to 30+s (large); a slice is ~1–5s;
+a unit test is milliseconds. Push each test as far down the pyramid as it will go.
+
+## Context caching: why a big integration suite can still be fast
+
+Spring reuses a loaded `ApplicationContext` across test classes. The first integration
+test pays the startup cost; every later test with an **identical configuration** reuses the
+cached context for free. Getting this right is the difference between a suite that takes
+minutes and one that takes tens of minutes — one team cut 150 integration tests from
+**26 minutes to 12** purely by improving cache reuse.
+
+The cache key is the **`MergedContextConfiguration`** — Spring reuses a context only when
+all of these match:
+
+- configuration classes (`@SpringBootTest` classes / `@Import`s)
+- active profiles (`@ActiveProfiles`)
+- properties (`@TestPropertySource` and inline `properties = …`)
+- **mock beans (`@MockitoBean` / `@MockitoSpyBean`)**
+- test property sources, context initializers, context customizers
+
+If any differ, Spring builds a **new** context (another 5–15s). So the anti-patterns are:
+
+- **Scattered `@MockitoBean` declarations** across test classes — each unique set is a new
+  context. Consolidate common mocks into an `abstract BaseIntegrationTest`.
+- **Scattered property overrides** (`@TestPropertySource`/inline per class) — put shared
+  test config in `application-test.properties` and use `@ActiveProfiles("test")`
+  consistently.
+- **`@DirtiesContext`** — it *discards* the cached context; 10 uses ≈ 50–150s wasted. Fix
+  the isolation/cleanup root cause instead of reaching for it.
+
+**Do:** one `BaseIntegrationTest` with shared `@ActiveProfiles("test")`, consolidated
+`@MockitoBean`s, and shared `application-test.properties`. **Monitor** cache hits/misses
+with `<logger name="org.springframework.test.context.cache" level="DEBUG"/>` in
+`logback-test.xml`.
+
+## Keep real infrastructure affordable: one container for the suite
+
+Real-infrastructure slices (Testcontainers, see
+[testcontainers-wiring.md](testcontainers-wiring.md)) are only cheap if the container is
+reused. Start **one** container for the whole suite — a `static` container, or (preferred)
+a shared `@ServiceConnection` bean in an imported config — rather than one per class. This
+is what makes "always use a real database" practical at scale, and it composes with
+context caching above.
+
+## Mocking is a boundary tool, not a default
+
+Mock at architectural boundaries (external services, clock, randomness); use real value
+objects and pure logic. Over-mocking couples tests to internals and makes refactoring
+scary rather than safe — assert *what* the code produces, not *how*. Details and examples:
+[testing-unit-mocking.md](testing-unit-mocking.md).
+
+## 3.5.x vs 4.x
+
+- Context caching and its cache key work the same on both lines.
+- **4.x-only: context pausing** (Spring Framework 7). Cached contexts freeze `@Scheduled`
+  tasks, message listeners, and background threads *between* tests, then resume instantly —
+  making caching reliable without `@DirtiesContext` workarounds.
+- Cache-key mock beans are `@MockitoBean`/`@MockitoSpyBean` on both lines (`@MockBean` is
+  deprecated on 3.5.x and removed on 4.x).
+
+---
+
+*Strategy, the context-caching cost model, and the pyramid framing credit **Philip Riecks**,
+*Testing Spring Boot Applications Demystified* (v4.0).*

--- a/skills/spring-boot/references/testing-strategy.md
+++ b/skills/spring-boot/references/testing-strategy.md
@@ -107,9 +107,9 @@ Mockito generates classes at runtime, which the closed-world native image forbid
 - **For a native-safe bean replacement, prefer `@TestBean`** (a static factory method
   returning a real or hand-written stub) — the non-Mockito bean-override, and general Bean
   Override support, work in native image.
-- This is another reason to lean on **real-component / Testcontainers** tests (the sliced
-  Variant B and integration tests, which use no mocks): those run natively and are what
-  actually exercise native compatibility. See
+- This is another reason to lean on **real-component / Testcontainers** tests — the
+  real-database sliced tests and integration tests, which use no mocks — those run
+  natively and are what actually exercise native compatibility. See
   [testing-integration.md](testing-integration.md).
 
 Source: [Testing GraalVM Native Images](https://docs.spring.io/spring-boot/how-to/native-image/testing-native-applications.html).

--- a/skills/spring-boot/references/testing-strategy.md
+++ b/skills/spring-boot/references/testing-strategy.md
@@ -95,6 +95,25 @@ slow, paid OpenAI call while keeping the database real); keep everything else re
 rationale and the over-mocking smell live in
 [testing-unit-mocking.md](testing-unit-mocking.md).
 
+## GraalVM native-image testing: mocks don't work
+
+If you run the suite as a native image (`mvn -PnativeTest test` / `gradle nativeTest`) to
+validate native compatibility, **Mockito is not supported in a native image** — `@Mock`,
+`@MockitoBean`, `@MockitoSpyBean` (and 3.5.x's `@MockBean`/`@SpyBean`) fail there because
+Mockito generates classes at runtime, which the closed-world native image forbids.
+
+- **Skip mock-based tests in native runs** with JUnit's `@DisabledInNativeImage` on the
+  affected classes/methods.
+- **For a native-safe bean replacement, prefer `@TestBean`** (a static factory method
+  returning a real or hand-written stub) — the non-Mockito bean-override, and general Bean
+  Override support, work in native image.
+- This is another reason to lean on **real-component / Testcontainers** tests (the sliced
+  Variant B and integration tests, which use no mocks): those run natively and are what
+  actually exercise native compatibility. See
+  [testing-integration.md](testing-integration.md).
+
+Source: [Testing GraalVM Native Images](https://docs.spring.io/spring-boot/how-to/native-image/testing-native-applications.html).
+
 ## 3.5.x vs 4.x
 
 - Context caching and its cache key work the same on both lines.

--- a/skills/spring-boot/references/testing-strategy.md
+++ b/skills/spring-boot/references/testing-strategy.md
@@ -1,83 +1,119 @@
-# Testing Strategy: Choosing the Level & Keeping the Suite Fast
+# Testing Strategy: Layered Tests & Keeping the Suite Fast
 
-Read this to decide *which kind* of test to write, and why a large Spring Boot suite stays
-fast. The individual how-tos live in the leaf references linked below.
+Read this to decide *which levels* of test to write, and why a large Spring Boot suite
+stays fast. The individual how-tos live in the leaf references linked below.
 
-## Match the test to what you are testing
+## The levels are complementary, not either/or
 
-The pyramid: many fast **unit** tests at the base, fewer **slice** tests in the middle, a
-thin layer of **integration/e2e** tests on top.
+Slice tests and end-to-end tests are **not** a choice — you write both, because each
+catches bugs the others structurally cannot:
 
-| You are testing… | Level | Reference |
+- A **pure unit test** (Mockito, no framework) can have ~100% coverage and still pass
+  while the app is broken: it ignores the persistence mapping, the request mapping, the
+  serialization, the security config, and every annotation. A missing `@Controller` (or a
+  schema/mapping mismatch) makes the endpoint return nothing in production — the unit test
+  never notices.
+- A **whole-application smoke test** catches wiring/startup failures (a bad bean
+  definition, a mapping that doesn't resolve) but, as a black box, tells you little about
+  *where* a behavioural bug is and is slow to run.
+- A **sliced Spring test** boots the real framework around the components under test, so it
+  catches annotation/mapping/SQL bugs a unit test misses — while staying fast.
+
+So layer them. The mistake is assuming green unit tests mean you can skip the tests that
+boot the framework.
+
+## The recommended distribution (Paul Bakker / Netflix)
+
+Roughly:
+
+- **~95% — sliced Spring tests.** `@SpringBootTest(classes = { … })` bootstraps *only* the
+  components you list (plus core DI), not the whole app — as fast as a unit test, but with
+  the real framework, annotations, and (via Testcontainers) real SQL. Mock the slow/costly
+  externals with a `@TestConfiguration` bean override or `@MockitoBean`; keep the rest
+  real. The built-in slice annotations (`@WebMvcTest`, `@DataJpaTest`, `@JsonTest`, …) are
+  the *same mechanism* with a preconfigured slice — convenient, but sometimes limiting, in
+  which case fall back to an explicit `classes = { … }` list (optionally with a custom
+  test-slice meta-annotation). See [testing-integration.md](testing-integration.md),
+  [testing-slices-web.md](testing-slices-web.md),
+  [testing-slices-persistence.md](testing-slices-persistence.md).
+- **At least one smoke test**, plus at least one **request-level** end-to-end test.
+  An (almost empty) `@SpringBootTest` proves the whole context starts; for a web/REST
+  service, one request driven through the full stack proves the wiring actually serves a
+  response. See [testing-integration.md](testing-integration.md) and
+  [spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md).
+- **Some unit tests** for complex framework-free business logic — fine, just rarely
+  sufficient on their own. See [testing-unit-mocking.md](testing-unit-mocking.md).
+
+### Which level(s) for what
+
+| You are testing… | Reach for | Reference |
 |---|---|---|
-| Business/domain logic, no framework | Unit (no context) | [testing-unit-mocking.md](testing-unit-mocking.md) |
+| Complex framework-free business logic | Unit (no context) | [testing-unit-mocking.md](testing-unit-mocking.md) |
 | Repository / JDBC / jOOQ queries | Persistence slice + Testcontainers | [testing-slices-persistence.md](testing-slices-persistence.md) |
 | Controller, JSON, or a REST client | Web slice | [testing-slices-web.md](testing-slices-web.md) |
-| The assembled system / external HTTP | Integration `@SpringBootTest` | [testing-integration.md](testing-integration.md) |
+| A handful of components working together | Sliced `@SpringBootTest(classes = …)` | [testing-integration.md](testing-integration.md) |
+| The whole app starts / one real request end-to-end | Smoke + request-level e2e | [testing-integration.md](testing-integration.md) |
 | Full REST API over a real port | End-to-end | [spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) |
 
-The common failure is the **wrong altitude** — reaching for `@SpringBootTest` to test
-pure logic. Full context startup is ~5–15s (medium app) to 30+s (large); a slice is ~1–5s;
-a unit test is milliseconds. Push each test as far down the pyramid as it will go.
+## Why the sliced test is the workhorse: context cost
 
-## Context caching: why a big integration suite can still be fast
+Full-context `@SpringBootTest` startup is the expensive part — ~5–15s for a medium app,
+30s to several minutes for a large one (data init, cache warming, IPC). That is why the
+*sliced* Spring test (small context) is the default and full-context tests are kept to the
+smoke/e2e handful — not because slices and e2e are alternatives, but because the full
+context is what's slow.
 
-Spring reuses a loaded `ApplicationContext` across test classes. The first integration
-test pays the startup cost; every later test with an **identical configuration** reuses the
-cached context for free. Getting this right is the difference between a suite that takes
-minutes and one that takes tens of minutes — one team cut 150 integration tests from
-**26 minutes to 12** purely by improving cache reuse.
+## Context caching: keeping the boot cost paid once
+
+Spring reuses a loaded `ApplicationContext` across test classes with an identical
+configuration; the first test pays startup, later ones reuse it for free. Getting this
+right is the difference between minutes and tens of minutes — one team cut 150 integration
+tests from **26 to 12 minutes** purely by improving reuse.
 
 The cache key is the **`MergedContextConfiguration`** — Spring reuses a context only when
-all of these match:
+all of these match: configuration classes / `classes`, active profiles (`@ActiveProfiles`),
+properties (`@TestPropertySource` and inline `properties`), **mock beans (`@MockitoBean` /
+`@MockitoSpyBean`)**, and the test's initializers/customizers. If any differ, Spring builds
+a new context (another full startup). Both Riecks and Bakker call out the same trap:
+**adding a `@MockitoBean` (or scattered property overrides) forks the cache** and forces a
+re-initialization. So:
 
-- configuration classes (`@SpringBootTest` classes / `@Import`s)
-- active profiles (`@ActiveProfiles`)
-- properties (`@TestPropertySource` and inline `properties = …`)
-- **mock beans (`@MockitoBean` / `@MockitoSpyBean`)**
-- test property sources, context initializers, context customizers
+- Consolidate common mocks into an `abstract BaseIntegrationTest`; don't sprinkle
+  `@MockitoBean` per class.
+- Put shared config in `application-test.properties` + `@ActiveProfiles("test")`.
+- Avoid `@DirtiesContext` — it discards the cached context (10 uses ≈ 50–150s wasted); fix
+  the isolation root cause instead.
+- Monitor with `<logger name="org.springframework.test.context.cache" level="DEBUG"/>`.
 
-If any differ, Spring builds a **new** context (another 5–15s). So the anti-patterns are:
+## Keep real infrastructure affordable: one container per suite
 
-- **Scattered `@MockitoBean` declarations** across test classes — each unique set is a new
-  context. Consolidate common mocks into an `abstract BaseIntegrationTest`.
-- **Scattered property overrides** (`@TestPropertySource`/inline per class) — put shared
-  test config in `application-test.properties` and use `@ActiveProfiles("test")`
-  consistently.
-- **`@DirtiesContext`** — it *discards* the cached context; 10 uses ≈ 50–150s wasted. Fix
-  the isolation/cleanup root cause instead of reaching for it.
+Real-infra tests (Testcontainers, see [testcontainers-wiring.md](testcontainers-wiring.md))
+are only cheap if the container is reused: start **one** container for the whole suite (a
+`static` container or a shared `@ServiceConnection` bean), not one per class. On CI where
+Docker isn't available on the host (e.g. Jenkins), Testcontainers Cloud runs the container
+remotely with transparent port-forwarding. This composes with context caching to make
+"always use a real database" practical at scale.
 
-**Do:** one `BaseIntegrationTest` with shared `@ActiveProfiles("test")`, consolidated
-`@MockitoBean`s, and shared `application-test.properties`. **Monitor** cache hits/misses
-with `<logger name="org.springframework.test.context.cache" level="DEBUG"/>` in
-`logback-test.xml`.
+## Mocking is a boundary tool
 
-## Keep real infrastructure affordable: one container for the suite
-
-Real-infrastructure slices (Testcontainers, see
-[testcontainers-wiring.md](testcontainers-wiring.md)) are only cheap if the container is
-reused. Start **one** container for the whole suite — a `static` container, or (preferred)
-a shared `@ServiceConnection` bean in an imported config — rather than one per class. This
-is what makes "always use a real database" practical at scale, and it composes with
-context caching above.
-
-## Mocking is a boundary tool, not a default
-
-Mock at architectural boundaries (external services, clock, randomness); use real value
-objects and pure logic. Over-mocking couples tests to internals and makes refactoring
-scary rather than safe — assert *what* the code produces, not *how*. Details and examples:
-[testing-unit-mocking.md](testing-unit-mocking.md).
+Mock at architectural boundaries (external services, clock, randomness) — Bakker's example
+mocks the slow, paid OpenAI call while keeping the database real; use real value objects and
+pure logic elsewhere. Over-mocking couples tests to internals; assert *what* the code
+produces, not *how*. See [testing-unit-mocking.md](testing-unit-mocking.md).
 
 ## 3.5.x vs 4.x
 
 - Context caching and its cache key work the same on both lines.
-- **4.x-only: context pausing** (Spring Framework 7). Cached contexts freeze `@Scheduled`
-  tasks, message listeners, and background threads *between* tests, then resume instantly —
-  making caching reliable without `@DirtiesContext` workarounds.
-- Cache-key mock beans are `@MockitoBean`/`@MockitoSpyBean` on both lines (`@MockBean` is
-  deprecated on 3.5.x and removed on 4.x).
+- **4.x-only: context pausing** (Spring Framework 7) freezes `@Scheduled` tasks and
+  listeners in cached contexts between tests, then resumes instantly — reducing the need for
+  `@DirtiesContext`. 4.x also improves bean-override ergonomics for `@TestConfiguration`.
+- Cache-key mock beans are `@MockitoBean`/`@MockitoSpyBean` on both lines (`@MockBean`
+  deprecated on 3.5.x, removed on 4.x).
 
 ---
 
-*Strategy, the context-caching cost model, and the pyramid framing credit **Philip Riecks**,
-*Testing Spring Boot Applications Demystified* (v4.0).*
+*The layered model and the ~95%-sliced-tests distribution credit **Paul Bakker** (Netflix,
+Java Champion), *Testing Spring Boot the Netflix Way* —
+[github.com/paulbakker/testing-spring-boot-presentation](https://github.com/paulbakker/testing-spring-boot-presentation).
+The context-caching cost model and pyramid framing credit **Philip Riecks**, *Testing
+Spring Boot Applications Demystified* (v4.0).*

--- a/skills/spring-boot/references/testing-strategy.md
+++ b/skills/spring-boot/references/testing-strategy.md
@@ -46,16 +46,8 @@ Roughly:
 - **Some unit tests** for complex framework-free business logic — fine, just rarely
   sufficient on their own. See [testing-unit-mocking.md](testing-unit-mocking.md).
 
-### Which level(s) for what
-
-| You are testing… | Reach for | Reference |
-|---|---|---|
-| Complex framework-free business logic | Unit (no context) | [testing-unit-mocking.md](testing-unit-mocking.md) |
-| Repository / JDBC / jOOQ queries | Persistence slice + Testcontainers | [testing-slices-persistence.md](testing-slices-persistence.md) |
-| Controller, JSON, or a REST client | Web slice | [testing-slices-web.md](testing-slices-web.md) |
-| A handful of components working together | Sliced `@SpringBootTest(classes = …)` | [testing-integration.md](testing-integration.md) |
-| The whole app starts / one real request end-to-end | Smoke + request-level e2e | [testing-integration.md](testing-integration.md) |
-| Full REST API over a real port | End-to-end | [spring-boot-rest-api-testing.md](spring-boot-rest-api-testing.md) |
+For the "what am I testing → which reference" lookup, use the decision table in `SKILL.md`
+(always in context). This file is the *why* behind that table.
 
 ## Why the sliced test is the workhorse: context cost
 
@@ -98,10 +90,10 @@ remotely with transparent port-forwarding. This composes with context caching to
 
 ## Mocking is a boundary tool
 
-Mock at architectural boundaries (external services, clock, randomness) — Bakker's example
-mocks the slow, paid OpenAI call while keeping the database real; use real value objects and
-pure logic elsewhere. Over-mocking couples tests to internals; assert *what* the code
-produces, not *how*. See [testing-unit-mocking.md](testing-unit-mocking.md).
+Mock at architectural boundaries — external services, clock, randomness (Bakker mocks the
+slow, paid OpenAI call while keeping the database real); keep everything else real. The full
+rationale and the over-mocking smell live in
+[testing-unit-mocking.md](testing-unit-mocking.md).
 
 ## 3.5.x vs 4.x
 

--- a/skills/spring-boot/references/testing-unit-mocking.md
+++ b/skills/spring-boot/references/testing-unit-mocking.md
@@ -42,6 +42,8 @@ Over-mocking is a smell. Two habits keep tests refactor-safe:
 - **Use `verify()` sparingly** — mainly to prove a side effect happened (a charge was
   issued) or did *not* (`verifyNoInteractions(paymentGateway)` for an empty cart).
 
+## Keep cases DRY
+
 Collapse near-identical cases with `@ParameterizedTest` (`@ValueSource` / `@CsvSource` /
 `@MethodSource`) rather than copy-pasting test methods.
 

--- a/skills/spring-boot/references/testing-unit-mocking.md
+++ b/skills/spring-boot/references/testing-unit-mocking.md
@@ -60,6 +60,10 @@ This layer is version-agnostic: the only difference is the JUnit version — **J
 3.5.x, **JUnit 6** on 4.x — which does not change any of the code above. Mockito and
 AssertJ come transitively via the test starter in both lines.
 
+> **GraalVM native image:** Mockito does not work in a native image, so `@Mock`-based tests
+> (and `@MockitoBean`) can't run under `nativeTest` — see the native-image caveat in
+> [testing-strategy.md](testing-strategy.md).
+
 ---
 
 *Unit-testing and mocking guidance credit **Philip Riecks**, *Testing Spring Boot

--- a/skills/spring-boot/references/testing-unit-mocking.md
+++ b/skills/spring-boot/references/testing-unit-mocking.md
@@ -1,0 +1,77 @@
+# Unit Testing & Mocking (no Spring context)
+
+The base of the pyramid: test business/domain logic in plain JUnit + Mockito + AssertJ
+with **no Spring context**. These run in milliseconds, so most of your tests should live
+here. You are testing *your* code, not the framework — Spring has its own tests.
+
+Constructor injection is what makes a Spring bean trivially unit-testable: instantiate it
+with test doubles, no container required.
+
+```java
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock OrderRepository orderRepository;   // collaborator at a boundary -> mock
+    @Mock PaymentGateway paymentGateway;     // external service -> mock
+    @InjectMocks OrderService orderService;
+
+    @Test
+    void placesOrderAndCharges() {
+        var command = new PlaceOrder("SKU-1", 2);
+        when(orderRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Order order = orderService.place(command);
+
+        assertThat(order.status()).isEqualTo(OrderStatus.PLACED);
+        verify(paymentGateway).charge(order.total());
+    }
+}
+```
+
+## What to mock — and what not to
+
+Mock at **architectural boundaries**: external services, the database/repository, the
+clock, randomness. Use the **real** thing for value objects, domain entities, and pure
+logic — mocking those just couples the test to internals.
+
+Over-mocking is a smell. Two habits keep tests refactor-safe:
+
+- **Assert behaviour, not implementation.** Verify *what* the code produces, not *how* it
+  computed it. Testing `spy(service).verify(internalSortMethod())` locks the test to the
+  implementation; asserting the returned list is sorted does not.
+- **Use `verify()` sparingly** — mainly to prove a side effect happened (a charge was
+  issued) or did *not* (`verifyNoInteractions(paymentGateway)` for an empty cart).
+
+## Parameterized tests over duplication
+
+Collapse near-identical cases with `@ParameterizedTest` + `@ValueSource` / `@CsvSource`:
+
+```java
+@ParameterizedTest
+@CsvSource({
+    "978-0132350884, true",
+    "invalid-isbn,   false",
+    "123,            false",
+})
+void validatesIsbn(String isbn, boolean expected) {
+    assertThat(validator.isValid(isbn)).isEqualTo(expected);
+}
+```
+
+## What not to unit-test at all
+
+Getters/setters, framework wiring (`@Autowired` injection works — that's Spring's job),
+and private methods via reflection (if a private method needs its own test, extract it to
+a class of its own). Prefer AssertJ's fluent assertions (`extracting`, `satisfies`,
+`containsExactlyInAnyOrder`) for readable expectations.
+
+## 3.5.x vs 4.x
+
+This layer is version-agnostic: the only difference is the JUnit version — **JUnit 5** on
+3.5.x, **JUnit 6** on 4.x — which does not change any of the code above. Mockito and
+AssertJ come transitively via the test starter in both lines.
+
+---
+
+*Unit-testing and mocking guidance credit **Philip Riecks**, *Testing Spring Boot
+Applications Demystified* (v4.0).*

--- a/skills/spring-boot/references/testing-unit-mocking.md
+++ b/skills/spring-boot/references/testing-unit-mocking.md
@@ -42,21 +42,8 @@ Over-mocking is a smell. Two habits keep tests refactor-safe:
 - **Use `verify()` sparingly** — mainly to prove a side effect happened (a charge was
   issued) or did *not* (`verifyNoInteractions(paymentGateway)` for an empty cart).
 
-## Parameterized tests over duplication
-
-Collapse near-identical cases with `@ParameterizedTest` + `@ValueSource` / `@CsvSource`:
-
-```java
-@ParameterizedTest
-@CsvSource({
-    "978-0132350884, true",
-    "invalid-isbn,   false",
-    "123,            false",
-})
-void validatesIsbn(String isbn, boolean expected) {
-    assertThat(validator.isValid(isbn)).isEqualTo(expected);
-}
-```
+Collapse near-identical cases with `@ParameterizedTest` (`@ValueSource` / `@CsvSource` /
+`@MethodSource`) rather than copy-pasting test methods.
 
 ## What not to unit-test at all
 


### PR DESCRIPTION
## What

Adds comprehensive testing guidance to the `spring-boot` skill: six focused reference
files plus a decision table in `SKILL.md` that routes to them. Covers the full range of
Spring Boot tests — unit/mocking, slice tests (web + persistence), sliced-context and
end-to-end integration — with Spring Boot **3.5.x vs 4.x** differences called out
throughout and grounded in the official Spring Boot testing reference.

**Framing: the levels are complementary, not either/or.** Following Paul Bakker's (Netflix)
approach, most framework-touching tests live at a fast **sliced Spring context**
(`@SpringBootTest(classes = { … })` paired with a test slice, or a slice annotation),
complemented by at least one **smoke test** and one **request-level end-to-end** test, plus
unit tests for framework-free logic. Slices and end-to-end catch different bugs — you write
both.

## New references

- `testing-strategy.md` — the layered model and recommended distribution; the
  **context-caching cost model** (cache key = `MergedContextConfiguration`; what forks the
  cache; one container per suite; Testcontainers Cloud on CI); and the **GraalVM
  native-image** caveat (Mockito is unsupported under `nativeTest`).
- `testing-unit-mocking.md` — JUnit + Mockito + AssertJ, no Spring context; mock at
  boundaries; behaviour over implementation.
- `testing-slices-persistence.md` — `@DataJpaTest`, `@JdbcTest` (incl. `JdbcClient`),
  `@DataJdbcTest`, `@JooqTest` — all backed by **Testcontainers with a real database**
  (`@AutoConfigureTestDatabase(replace = NONE)`), never in-memory H2.
- `testing-slices-web.md` — `@WebMvcTest`, `@JsonTest`, `@RestClientTest`; the
  "security isn't auto-applied in slices → `@Import(SecurityConfig.class)`" gotcha.
- `testing-integration.md` — smoke tests (startup + request-level), the
  `@SpringBootTest(classes = …)` **sliced-context workhorse** with a custom
  `@EnableDatabaseTest` Testcontainers slice, external HTTP (built-in
  `@RestClientTest`/`MockRestServiceServer` first, WireMock only when you need a real port),
  and the Boot 4 `RestTestClient` bind modes spanning slice-to-e2e.
- `testcontainers-wiring.md` — the `@ServiceConnection` support matrix, the
  `@DynamicPropertySource`-vs-static-properties decision, and a **"when Docker isn't
  available"** caveat (`disabledWithoutDocker` / Docker-availability conditions;
  Testcontainers Cloud on CI).

`SKILL.md` gains a `## Testing` decision table linking these directly; the two existing
testing references get cross-links and short 3.5.x-vs-4.x notes.

## Credits

- **Paul Bakker** (Netflix, Java Champion) — the layered testing model, smoke tests, the
  `@SpringBootTest(classes = …)` sliced-context approach, and the custom `@EnableDatabaseTest`
  Testcontainers slice: <https://github.com/paulbakker/testing-spring-boot-presentation>
- **Philip Riecks** — *Testing Spring Boot Applications Demystified* (v4.0) and his webinar:
  slice/mocking patterns, the context-caching cost model, WireMock.
- **Siva Prasad Reddy Katamreddy** — Testcontainers patterns
  ([testcontainers-samples](https://github.com/sivaprasadreddy/testcontainers-samples),
  [sivalabs.in/tags/testcontainers](https://www.sivalabs.in/tags/testcontainers/)).
- **Dan Vega** — Spring Framework 7 `RestTestClient` bind modes:
  <https://www.danvega.dev/blog/spring-framework-7-rest-test-client>

API details verified against the official Spring Boot 4.x testing reference and framework
source.

> Draft: opening for review/discussion before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
